### PR TITLE
fix(Types): fix data type signatures and add Eff

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
     "output"
   ],
   "dependencies": {
-    "purescript-maybe": "^0.3.5"
+    "purescript-maybe": "^0.3.5",
+    "purescript-eff": "^0.1.2"
   },
   "version": "0.0.1"
 }

--- a/src/Almost.purs
+++ b/src/Almost.purs
@@ -1,19 +1,20 @@
 module Almost where
 
 import Data.Maybe (Maybe)
+import Control.Monad.Eff (Eff, Pure)
 
 newtype Undefined a = Undefined (Maybe a)
-newtype Stream a = Stream a
-newtype Subject a = Subject a
 
+foreign import data Subject :: * -> *
+foreign import data Stream :: * -> *
 foreign import data Promise :: * -> *
 
 {-Sad subject type stuff -}
 foreign import subject :: forall a. Subject a
 foreign import holdSubject :: forall a. Int -> Subject a
 
-foreign import next :: forall a. a -> Subject a -> Subject a
-foreign import complete :: forall a. a -> Subject a -> Subject a
+foreign import next :: forall a. a -> Subject a -> Pure (Subject a)
+foreign import complete :: forall a. a -> Subject a -> Pure (Subject a)
 
 {- create streams -}
 
@@ -23,7 +24,7 @@ foreign import never :: forall a. a -> Stream (Undefined a)
 foreign import periodic :: Int -> forall a. a -> Stream a
 
 {- consume streams -}
-foreign import observe :: forall a b. (a -> b) -> Stream a -> Promise a
+foreign import observe :: forall a b eff. (a -> Eff eff b) -> Stream a -> Promise a
 foreign import drain :: forall a. Stream a -> Promise a
 {- then a Promise -}
 foreign import thenp :: forall a b. (a -> b) -> Promise a -> Promise b


### PR DESCRIPTION
makes the types make a little more nice and sets it up to instance Functor and whatnot easily

and then observers do end up making some kind of effect on subscription, and sending data through subjects is a "pure" operation.
